### PR TITLE
Fix for issue #19776

### DIFF
--- a/common/api/__init__.py
+++ b/common/api/__init__.py
@@ -27,7 +27,7 @@ class Api():
       'iat': now,
       'exp': now + timedelta(hours=1)
     }
-    return jwt.encode(payload, self.private_key, algorithm='RS256').decode('utf8')
+    return bytes(jwt.encode(payload, self.private_key, algorithm='RS256'), 'utf8')
 
 def api_get(endpoint, method='GET', timeout=None, access_token=None, **params):
   backend = "https://api.commadotai.com/"


### PR DESCRIPTION
PyJWT 2.0.0 does not return `bytes` for `encode()` instead returns `str`. So converted the `str` to `bytes` and returned the resulting value

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Car bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

**Route**
Route: [a route with the bug fix]

-->

<!--- ***** Template: Bug fix *****

**Description** [](A description of the bug and the fix. Also link any relevant issues.)

**Verification** [](Explain how you tested this bug fix.)

-->

<!--- ***** Template: Car port *****

**Checklist**
- [ ] added to README
- [ ] test route added to [test_car_models](../../selfdrive/test/test_car_models.py)
- [ ] route with openpilot:
- [ ] route with stock system:

-->

<!--- ***** Template: Refactor *****

**Description** [](A description of the refactor, including the goals it accomplishes.)

**Verification** [](Explain how you tested the refactor for regressions.)

-->
